### PR TITLE
Rebuild 0.2.6 for Windows

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+channels:
+  - mesters_ord: ruamel.yaml
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-channels:
-  mesters_org: ruamel.yaml
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
 channels:
-  - mesters_ord: ruamel.yaml
+  mesters_org: ruamel.yaml
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,7 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
+  license_url: https://sourceforge.net/p/ruamel-yaml-clib/code/ci/{{ version }}/tree/LICENSE
   summary: C version of reader, parser and emitter for ruamel.yaml derived from libyaml
   description: |
     This package was split of from ruamel.yaml, so that ruamel.yaml can be build as a universal wheel.
@@ -46,6 +47,7 @@ about:
     installation of the .so on Linux systems under /usr/lib64/pythonX.Y (without a .pth file or a ruamel
     directory) and the Python code for ruamel.yaml under /usr/lib/pythonX.Y.
   doc_url: https://yaml.readthedocs.io
+  doc_source_url: https://sourceforge.net/p/ruamel-yaml-clib/code/ci/{{ version }}/tree/_doc/
   dev_url: https://sourceforge.net/projects/ruamel-yaml-clib/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: C version of reader, parser and emitter for ruamel.yaml derived from libyaml
+  doc_url: http://yaml.readthedocs.io
+  dev_url: https://sourceforge.net/projects/ruamel-yaml-clib/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ about:
     Apart from the C code seldom changing, and taking a long time to compile for all platforms, this allows
     installation of the .so on Linux systems under /usr/lib64/pythonX.Y (without a .pth file or a ruamel
     directory) and the Python code for ruamel.yaml under /usr/lib/pythonX.Y.
-  doc_url: http://yaml.readthedocs.io
+  doc_url: https://yaml.readthedocs.io
   dev_url: https://sourceforge.net/projects/ruamel-yaml-clib/
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,7 @@ source:
 build:
   number: 1
   script: {{ PYTHON }} -m pip install . -vv
+  skip: True  # [py<35]
   ignore_run_exports:
     - python
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
   ignore_run_exports:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,11 +24,11 @@ requirements:
   run:
     - python
 
-# test:
-#   requires:
-#     - ruamel.yaml
-#   imports:
-#     - _ruamel_yaml
+test:
+  requires:
+    - ruamel.yaml
+  imports:
+    - _ruamel_yaml
 
 about:
   home: https://sourceforge.net/projects/ruamel-yaml-clib/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,6 +37,11 @@ about:
   license_family: MIT
   license_file: LICENSE
   summary: C version of reader, parser and emitter for ruamel.yaml derived from libyaml
+  description: |
+    This package was split of from ruamel.yaml, so that ruamel.yaml can be build as a universal wheel.
+    Apart from the C code seldom changing, and taking a long time to compile for all platforms, this allows
+    installation of the .so on Linux systems under /usr/lib64/pythonX.Y (without a .pth file or a ruamel
+    directory) and the Python code for ruamel.yaml under /usr/lib/pythonX.Y.
   doc_url: http://yaml.readthedocs.io
   dev_url: https://sourceforge.net/projects/ruamel-yaml-clib/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,10 @@ requirements:
 
 test:
   requires:
+    - pip
     - ruamel.yaml
+  commands:
+    - pip check
   imports:
     - _ruamel_yaml
 


### PR DESCRIPTION
This package was not available on Windows for python 3.8 and 3.9 and is required by ruamel.yaml

Jira ticket: [PKG-131](https://anaconda.atlassian.net/jira/software/c/projects/PKG/issues/PKG-131)

# Package Info

Home: https://sourceforge.net/projects/ruamel-yaml-clib/
Documentation: https://yaml.readthedocs.io/
Development: https://sourceforge.net/projects/ruamel-yaml-clib/