### PR TITLE
update to 0.2.8

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruamel.yaml.clib" %}
-{% set version = "0.2.7" %}
+{% set version = "0.2.8" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ruamel.yaml.clib-{{ version }}.tar.gz
-  sha256: 1f08fd5a2bea9c4180db71678e850b995d2a5f4537be0e94557668cf0f5f9497
+  sha256: beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   skip: True  # [py<35]
   ignore_run_exports:
     - python
@@ -40,7 +40,6 @@ about:
   license: MIT
   license_family: MIT
   license_file: LICENSE
-  license_url: https://sourceforge.net/p/ruamel-yaml-clib/code/ci/{{ version }}/tree/LICENSE
   summary: C version of reader, parser and emitter for ruamel.yaml derived from libyaml
   description: |
     This package was split of from ruamel.yaml, so that ruamel.yaml can be build as a universal wheel.
@@ -48,7 +47,6 @@ about:
     installation of the .so on Linux systems under /usr/lib64/pythonX.Y (without a .pth file or a ruamel
     directory) and the Python code for ruamel.yaml under /usr/lib/pythonX.Y.
   doc_url: https://yaml.readthedocs.io
-  doc_source_url: https://sourceforge.net/p/ruamel-yaml-clib/code/ci/{{ version }}/tree/_doc/
   dev_url: https://sourceforge.net/projects/ruamel-yaml-clib/
 
 extra:


### PR DESCRIPTION
ruamel.yaml.clib 0.2.8

**Destination channel:** main

### Links

- PKG-5763
- https://inspector.pypi.io/project/ruamel-yaml-clib/0.2.8/packages/46/ab/bab9eb1566cd16f060b54055dd39cf6a34bfa0240c53a7218c43e974295b/ruamel.yaml.clib-0.2.8.tar.gz/

