### PR TITLE
ruamel.yaml.clib 0.2.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ruamel.yaml.clib" %}
-{% set version = "0.2.8" %}
+{% set version = "0.2.12" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/ruamel.yaml.clib-{{ version }}.tar.gz
-  sha256: beb2e0404003de9a4cab9753a8805a8fe9320ee6673136ed7f04255fe60bb512
+  sha256: 6c8fbb13ec503f99a91901ab46e0b07ae7941cd527393187039aec586fdfd36f
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  skip: True  # [py<35]
+  skip: True  # [py<39]
   ignore_run_exports:
     - python
 requirements:


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-7509](https://anaconda.atlassian.net/browse/PKG-7509) 
- https://inspector.pypi.io/project/ruamel-yaml-clib/0.2.12/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz/

### Explanation of changes:

- Skip py<39

### Notes:

- It's a dependency for https://github.com/AnacondaRecipes/ruamel.yaml-feedstock/pull/16

[PKG-7509]: https://anaconda.atlassian.net/browse/PKG-7509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ